### PR TITLE
maybe fix missing identity after read

### DIFF
--- a/internal/provider/application_resource.go
+++ b/internal/provider/application_resource.go
@@ -308,8 +308,12 @@ func (r *ApplicationResource) Update(ctx context.Context, req resource.UpdateReq
 	}
 
 	retApp := clientAppToApplication(ctx, updatedApp)
+	retIdentity := IDIdentityModel{
+		ID: retApp.ID,
+	}
 
-	resp.State.Set(ctx, retApp)
+	resp.Diagnostics.Append(resp.State.Set(ctx, retApp)...)
+	resp.Diagnostics.Append(resp.Identity.Set(ctx, retIdentity)...)
 }
 
 func (r *ApplicationResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/provider/application_resource.go
+++ b/internal/provider/application_resource.go
@@ -304,6 +304,7 @@ func (r *ApplicationResource) Update(ctx context.Context, req resource.UpdateReq
 	updatedApp, err := r.client.Application.UpdateApplication(ctx, identity.ID.ValueString(), &app)
 	if err != nil {
 		resp.Diagnostics.AddError("Error Updating Application", err.Error())
+		resp.Diagnostics.Append(resp.Identity.Set(ctx, identity)...)
 		return
 	}
 

--- a/internal/provider/application_resource.go
+++ b/internal/provider/application_resource.go
@@ -265,11 +265,13 @@ func (r *ApplicationResource) Read(ctx context.Context, req resource.ReadRequest
 		id = state.ID.ValueString()
 	}
 
+	stateIdentity := IDIdentityModel{ID: state.ID}
+
 	app, err := r.client.Application.GetApplication(ctx, id)
 	if err != nil {
 		if strings.Contains(err.Error(), "unexpected status code: 404") {
 			resp.State.RemoveResource(ctx)
-			resp.Diagnostics.Append(resp.Identity.Set(ctx, IDIdentityModel{ID: state.ID})...)
+			resp.Diagnostics.Append(resp.Identity.Set(ctx, stateIdentity)...)
 			return
 		}
 		resp.Diagnostics.AddError("Error Reading Application", err.Error())

--- a/internal/provider/application_resource.go
+++ b/internal/provider/application_resource.go
@@ -269,6 +269,7 @@ func (r *ApplicationResource) Read(ctx context.Context, req resource.ReadRequest
 	if err != nil {
 		if strings.Contains(err.Error(), "unexpected status code: 404") {
 			resp.State.RemoveResource(ctx)
+			resp.Diagnostics.Append(resp.Identity.Set(ctx, IDIdentityModel{ID: state.ID})...)
 			return
 		}
 		resp.Diagnostics.AddError("Error Reading Application", err.Error())
@@ -301,10 +302,12 @@ func (r *ApplicationResource) Update(ctx context.Context, req resource.UpdateReq
 
 	app := applicationToClientApp(plan)
 
+	stateIdentity := IDIdentityModel{ID: state.ID}
+
 	updatedApp, err := r.client.Application.UpdateApplication(ctx, identity.ID.ValueString(), &app)
 	if err != nil {
 		resp.Diagnostics.AddError("Error Updating Application", err.Error())
-		resp.Diagnostics.Append(resp.Identity.Set(ctx, identity)...)
+		resp.Diagnostics.Append(resp.Identity.Set(ctx, stateIdentity)...)
 		return
 	}
 

--- a/internal/provider/fhir_resource.go
+++ b/internal/provider/fhir_resource.go
@@ -335,6 +335,11 @@ func (r *FhirResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		return
 	}
 
+	stateIdentity := FhirResourceIdentityModel{
+		ID:   state.ID,
+		Type: state.Type,
+	}
+
 	var versionID string
 	versionIDValue, ok := state.Meta.Attributes()["version_id"]
 	if ok && !versionIDValue.IsNull() {
@@ -346,12 +351,14 @@ func (r *FhirResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		updatedResource, err := r.client.Fhir.UpdateResource(ctx, state.Type.ValueString(), state.ID.ValueString(), versionID, resourceData)
 		if err != nil {
 			resp.Diagnostics.AddError("Error Updating FHIR Resource", err.Error())
+			resp.Diagnostics.Append(resp.Identity.Set(ctx, stateIdentity)...)
 			return
 		}
 
 		convertedResource, diags := convertRawResourceToFhirResource(ctx, updatedResource, plan)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
+			resp.Diagnostics.Append(resp.Identity.Set(ctx, stateIdentity)...)
 			return
 		}
 		resource = convertedResource

--- a/internal/provider/fhir_resource.go
+++ b/internal/provider/fhir_resource.go
@@ -366,7 +366,13 @@ func (r *FhirResource) Update(ctx context.Context, req resource.UpdateRequest, r
 		}
 	}
 
+	retIdentity := FhirResourceIdentityModel{
+		ID:   resource.ID,
+		Type: resource.Type,
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, resource)...)
+	resp.Diagnostics.Append(resp.Identity.Set(ctx, retIdentity)...)
 }
 
 func (r *FhirResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/provider/fhir_resource.go
+++ b/internal/provider/fhir_resource.go
@@ -295,11 +295,13 @@ func (r *FhirResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 
+	stateIdentity := FhirResourceIdentityModel{ID: state.ID, Type: state.Type}
+
 	returnedResource, err := r.client.Fhir.GetResource(ctx, state.Type.ValueString(), state.ID.ValueString())
 	if err != nil {
 		if strings.Contains(err.Error(), "unexpected status code: 410") {
 			resp.State.RemoveResource(ctx)
-			resp.Diagnostics.Append(resp.Identity.Set(ctx, FhirResourceIdentityModel{ID: state.ID, Type: state.Type})...)
+			resp.Diagnostics.Append(resp.Identity.Set(ctx, stateIdentity)...)
 			return
 		}
 		resp.Diagnostics.AddError("Error Reading FHIR Resource", err.Error())

--- a/internal/provider/fhir_resource.go
+++ b/internal/provider/fhir_resource.go
@@ -299,6 +299,7 @@ func (r *FhirResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	if err != nil {
 		if strings.Contains(err.Error(), "unexpected status code: 410") {
 			resp.State.RemoveResource(ctx)
+			resp.Diagnostics.Append(resp.Identity.Set(ctx, FhirResourceIdentityModel{ID: state.ID, Type: state.Type})...)
 			return
 		}
 		resp.Diagnostics.AddError("Error Reading FHIR Resource", err.Error())

--- a/internal/provider/m2m_resource.go
+++ b/internal/provider/m2m_resource.go
@@ -257,6 +257,7 @@ func (r *M2MResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	updatedM2M, err := r.client.M2M.UpdateM2M(ctx, state.ID.ValueString(), &m2m)
 	if err != nil {
 		resp.Diagnostics.AddError("Error Updating M2M", err.Error())
+		resp.Diagnostics.Append(resp.Identity.Set(ctx, IDIdentityModel{ID: state.ID})...)
 		return
 	}
 
@@ -265,6 +266,7 @@ func (r *M2MResource) Update(ctx context.Context, req resource.UpdateRequest, re
 		newSecret, err := r.client.M2M.RotateM2MSecret(ctx, state.ID.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError("Error Rotating M2M Secret", err.Error())
+			resp.Diagnostics.Append(resp.Identity.Set(ctx, IDIdentityModel{ID: state.ID})...)
 			return
 		}
 		clientSecret = newSecret

--- a/internal/provider/m2m_resource.go
+++ b/internal/provider/m2m_resource.go
@@ -271,8 +271,12 @@ func (r *M2MResource) Update(ctx context.Context, req resource.UpdateRequest, re
 	}
 
 	retM2M := convertClientM2MToM2M(ctx, updatedM2M, clientSecret, plan.ClientSecretVersion.ValueInt64())
+	retIdentity := IDIdentityModel{
+		ID: retM2M.ID,
+	}
 
-	resp.State.Set(ctx, retM2M)
+	resp.Diagnostics.Append(resp.State.Set(ctx, retM2M)...)
+	resp.Diagnostics.Append(resp.Identity.Set(ctx, retIdentity)...)
 }
 
 func (r *M2MResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/provider/m2m_resource.go
+++ b/internal/provider/m2m_resource.go
@@ -225,6 +225,7 @@ func (r *M2MResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 	if err != nil {
 		if strings.Contains(err.Error(), "unexpected status code: 404") {
 			resp.State.RemoveResource(ctx)
+			resp.Diagnostics.Append(resp.Identity.Set(ctx, IDIdentityModel{ID: state.ID})...)
 			return
 		}
 		resp.Diagnostics.AddError("Error Reading M2M", err.Error())
@@ -254,10 +255,12 @@ func (r *M2MResource) Update(ctx context.Context, req resource.UpdateRequest, re
 
 	m2m := convertM2MToClientM2M(ctx, plan)
 
+	stateIdentity := IDIdentityModel{ID: state.ID}
+
 	updatedM2M, err := r.client.M2M.UpdateM2M(ctx, state.ID.ValueString(), &m2m)
 	if err != nil {
 		resp.Diagnostics.AddError("Error Updating M2M", err.Error())
-		resp.Diagnostics.Append(resp.Identity.Set(ctx, IDIdentityModel{ID: state.ID})...)
+		resp.Diagnostics.Append(resp.Identity.Set(ctx, stateIdentity)...)
 		return
 	}
 
@@ -266,7 +269,7 @@ func (r *M2MResource) Update(ctx context.Context, req resource.UpdateRequest, re
 		newSecret, err := r.client.M2M.RotateM2MSecret(ctx, state.ID.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError("Error Rotating M2M Secret", err.Error())
-			resp.Diagnostics.Append(resp.Identity.Set(ctx, IDIdentityModel{ID: state.ID})...)
+			resp.Diagnostics.Append(resp.Identity.Set(ctx, stateIdentity)...)
 			return
 		}
 		clientSecret = newSecret

--- a/internal/provider/m2m_resource.go
+++ b/internal/provider/m2m_resource.go
@@ -221,11 +221,13 @@ func (r *M2MResource) Read(ctx context.Context, req resource.ReadRequest, resp *
 		id = state.ID.ValueString()
 	}
 
+	stateIdentity := IDIdentityModel{ID: state.ID}
+
 	m2m, err := r.client.M2M.GetM2M(ctx, id)
 	if err != nil {
 		if strings.Contains(err.Error(), "unexpected status code: 404") {
 			resp.State.RemoveResource(ctx)
-			resp.Diagnostics.Append(resp.Identity.Set(ctx, IDIdentityModel{ID: state.ID})...)
+			resp.Diagnostics.Append(resp.Identity.Set(ctx, stateIdentity)...)
 			return
 		}
 		resp.Diagnostics.AddError("Error Reading M2M", err.Error())

--- a/internal/provider/project_config_resource.go
+++ b/internal/provider/project_config_resource.go
@@ -178,6 +178,7 @@ func (r *ProjectConfigResource) Update(ctx context.Context, req resource.UpdateR
 	updatedProject, err := r.client.Project.UpdateProject(ctx, &updateParams)
 	if err != nil {
 		resp.Diagnostics.AddError("Error Updating Project Configuration", err.Error())
+		resp.Diagnostics.Append(resp.Identity.Set(ctx, IDIdentityModel{ID: plan.ID})...)
 		return
 	}
 

--- a/internal/provider/project_config_resource.go
+++ b/internal/provider/project_config_resource.go
@@ -182,8 +182,12 @@ func (r *ProjectConfigResource) Update(ctx context.Context, req resource.UpdateR
 	}
 
 	retProject := clientProjectToProject(ctx, updatedProject)
+	retIdentity := IDIdentityModel{
+		ID: retProject.ID,
+	}
 
-	resp.State.Set(ctx, retProject)
+	resp.Diagnostics.Append(resp.State.Set(ctx, retProject)...)
+	resp.Diagnostics.Append(resp.Identity.Set(ctx, retIdentity)...)
 }
 
 func (r *ProjectConfigResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/provider/project_config_resource.go
+++ b/internal/provider/project_config_resource.go
@@ -175,10 +175,12 @@ func (r *ProjectConfigResource) Update(ctx context.Context, req resource.UpdateR
 
 	updateParams := projectToClientProjectUpdateParams(plan)
 
+	stateIdentity := IDIdentityModel{ID: plan.ID}
+
 	updatedProject, err := r.client.Project.UpdateProject(ctx, &updateParams)
 	if err != nil {
 		resp.Diagnostics.AddError("Error Updating Project Configuration", err.Error())
-		resp.Diagnostics.Append(resp.Identity.Set(ctx, IDIdentityModel{ID: plan.ID})...)
+		resp.Diagnostics.Append(resp.Identity.Set(ctx, stateIdentity)...)
 		return
 	}
 

--- a/internal/provider/role_resource.go
+++ b/internal/provider/role_resource.go
@@ -185,6 +185,7 @@ func (r *RoleResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	updatedRole, err := r.client.Role.UpdateRole(ctx, state.ID.ValueString(), &role)
 	if err != nil {
 		resp.Diagnostics.AddError("Error Updating Role", err.Error())
+		resp.Diagnostics.Append(resp.Identity.Set(ctx, IDIdentityModel{ID: state.ID})...)
 		return
 	}
 

--- a/internal/provider/role_resource.go
+++ b/internal/provider/role_resource.go
@@ -189,8 +189,12 @@ func (r *RoleResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	}
 
 	retRole := convertClientRoleToRole(ctx, updatedRole)
+	retIdentity := IDIdentityModel{
+		ID: retRole.ID,
+	}
 
-	resp.State.Set(ctx, retRole)
+	resp.Diagnostics.Append(resp.State.Set(ctx, retRole)...)
+	resp.Diagnostics.Append(resp.Identity.Set(ctx, retIdentity)...)
 }
 
 func (r *RoleResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/provider/role_resource.go
+++ b/internal/provider/role_resource.go
@@ -149,11 +149,13 @@ func (r *RoleResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		id = state.ID.ValueString()
 	}
 
+	stateIdentity := IDIdentityModel{ID: state.ID}
+
 	role, err := r.client.Role.GetRole(ctx, id)
 	if err != nil {
 		if strings.Contains(err.Error(), "unexpected status code: 404") {
 			resp.State.RemoveResource(ctx)
-			resp.Diagnostics.Append(resp.Identity.Set(ctx, IDIdentityModel{ID: state.ID})...)
+			resp.Diagnostics.Append(resp.Identity.Set(ctx, stateIdentity)...)
 			return
 		}
 		resp.Diagnostics.AddError("Error Reading Role", err.Error())

--- a/internal/provider/role_resource.go
+++ b/internal/provider/role_resource.go
@@ -153,6 +153,7 @@ func (r *RoleResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	if err != nil {
 		if strings.Contains(err.Error(), "unexpected status code: 404") {
 			resp.State.RemoveResource(ctx)
+			resp.Diagnostics.Append(resp.Identity.Set(ctx, IDIdentityModel{ID: state.ID})...)
 			return
 		}
 		resp.Diagnostics.AddError("Error Reading Role", err.Error())
@@ -182,10 +183,12 @@ func (r *RoleResource) Update(ctx context.Context, req resource.UpdateRequest, r
 
 	role := convertRoleToClientRole(ctx, plan)
 
+	stateIdentity := IDIdentityModel{ID: state.ID}
+
 	updatedRole, err := r.client.Role.UpdateRole(ctx, state.ID.ValueString(), &role)
 	if err != nil {
 		resp.Diagnostics.AddError("Error Updating Role", err.Error())
-		resp.Diagnostics.Append(resp.Identity.Set(ctx, IDIdentityModel{ID: state.ID})...)
+		resp.Diagnostics.Append(resp.Identity.Set(ctx, stateIdentity)...)
 		return
 	}
 

--- a/internal/provider/secret_resource.go
+++ b/internal/provider/secret_resource.go
@@ -180,6 +180,7 @@ func (r *SecretResource) Update(ctx context.Context, req resource.UpdateRequest,
 	updatedSecret, err := r.client.Secret.SetSecret(ctx, &secret)
 	if err != nil {
 		resp.Diagnostics.AddError("Error Updating Secret", err.Error())
+		resp.Diagnostics.Append(resp.Identity.Set(ctx, SecretIdentityModel{Name: plan.Name})...)
 		return
 	}
 

--- a/internal/provider/secret_resource.go
+++ b/internal/provider/secret_resource.go
@@ -183,7 +183,13 @@ func (r *SecretResource) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
-	resp.State.Set(ctx, convertClientSecretToSecret(ctx, updatedSecret))
+	retSecret := convertClientSecretToSecret(ctx, updatedSecret)
+	retIdentity := SecretIdentityModel{
+		Name: retSecret.Name,
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, retSecret)...)
+	resp.Diagnostics.Append(resp.Identity.Set(ctx, retIdentity)...)
 }
 
 func (r *SecretResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/provider/secret_resource.go
+++ b/internal/provider/secret_resource.go
@@ -151,6 +151,7 @@ func (r *SecretResource) Read(ctx context.Context, req resource.ReadRequest, res
 	if err != nil {
 		if strings.Contains(err.Error(), "unexpected status code: 404") {
 			resp.State.RemoveResource(ctx)
+			resp.Diagnostics.Append(resp.Identity.Set(ctx, SecretIdentityModel{Name: state.Name})...)
 			return
 		}
 		resp.Diagnostics.AddError("Error Reading Secret", err.Error())
@@ -177,10 +178,12 @@ func (r *SecretResource) Update(ctx context.Context, req resource.UpdateRequest,
 
 	secret := convertSecretToClientSecret(ctx, plan)
 
+	stateIdentity := SecretIdentityModel{Name: plan.Name}
+
 	updatedSecret, err := r.client.Secret.SetSecret(ctx, &secret)
 	if err != nil {
 		resp.Diagnostics.AddError("Error Updating Secret", err.Error())
-		resp.Diagnostics.Append(resp.Identity.Set(ctx, SecretIdentityModel{Name: plan.Name})...)
+		resp.Diagnostics.Append(resp.Identity.Set(ctx, stateIdentity)...)
 		return
 	}
 

--- a/internal/provider/secret_resource.go
+++ b/internal/provider/secret_resource.go
@@ -147,11 +147,13 @@ func (r *SecretResource) Read(ctx context.Context, req resource.ReadRequest, res
 		name = state.Name.ValueString()
 	}
 
+	stateIdentity := SecretIdentityModel{Name: state.Name}
+
 	secret, err := r.client.Secret.GetSecret(ctx, name)
 	if err != nil {
 		if strings.Contains(err.Error(), "unexpected status code: 404") {
 			resp.State.RemoveResource(ctx)
-			resp.Diagnostics.Append(resp.Identity.Set(ctx, SecretIdentityModel{Name: state.Name})...)
+			resp.Diagnostics.Append(resp.Identity.Set(ctx, stateIdentity)...)
 			return
 		}
 		resp.Diagnostics.AddError("Error Reading Secret", err.Error())

--- a/internal/provider/z3_bucket_resource.go
+++ b/internal/provider/z3_bucket_resource.go
@@ -182,6 +182,7 @@ func (r *Z3BucketResource) Update(ctx context.Context, req resource.UpdateReques
 			"Name Change Not Allowed",
 			"The name of a Z3 bucket cannot be changed after creation. Please create a new bucket with the desired name.",
 		)
+		resp.Diagnostics.Append(resp.Identity.Set(ctx, Z3BucketIdentityModel{Name: state.Name})...)
 		return
 	}
 	retZ3Bucket := Z3Bucket{

--- a/internal/provider/z3_bucket_resource.go
+++ b/internal/provider/z3_bucket_resource.go
@@ -189,7 +189,12 @@ func (r *Z3BucketResource) Update(ctx context.Context, req resource.UpdateReques
 		Name:          state.Name,
 		RemovalPolicy: plan.RemovalPolicy,
 	}
+	retIdentity := Z3BucketIdentityModel{
+		Name: retZ3Bucket.Name,
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, retZ3Bucket)...)
+	resp.Diagnostics.Append(resp.Identity.Set(ctx, retIdentity)...)
 }
 
 func (r *Z3BucketResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/provider/z3_bucket_resource.go
+++ b/internal/provider/z3_bucket_resource.go
@@ -154,6 +154,7 @@ func (r *Z3BucketResource) Read(ctx context.Context, req resource.ReadRequest, r
 	if err != nil {
 		if strings.Contains(err.Error(), "unexpected status code: 404") {
 			resp.State.RemoveResource(ctx)
+			resp.Diagnostics.Append(resp.Identity.Set(ctx, Z3BucketIdentityModel{Name: state.Name})...)
 			return
 		}
 		resp.Diagnostics.AddError("Error Reading Z3 Bucket", err.Error())
@@ -177,12 +178,14 @@ func (r *Z3BucketResource) Update(ctx context.Context, req resource.UpdateReques
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	stateIdentity := Z3BucketIdentityModel{Name: state.Name}
+
 	if state.Name.ValueString() != plan.Name.ValueString() {
 		resp.Diagnostics.AddError(
 			"Name Change Not Allowed",
 			"The name of a Z3 bucket cannot be changed after creation. Please create a new bucket with the desired name.",
 		)
-		resp.Diagnostics.Append(resp.Identity.Set(ctx, Z3BucketIdentityModel{Name: state.Name})...)
+		resp.Diagnostics.Append(resp.Identity.Set(ctx, stateIdentity)...)
 		return
 	}
 	retZ3Bucket := Z3Bucket{

--- a/internal/provider/z3_bucket_resource.go
+++ b/internal/provider/z3_bucket_resource.go
@@ -150,11 +150,13 @@ func (r *Z3BucketResource) Read(ctx context.Context, req resource.ReadRequest, r
 		return
 	}
 
+	stateIdentity := Z3BucketIdentityModel{Name: state.Name}
+
 	clientBucket, err := r.client.Z3.GetBucket(ctx, state.Name.ValueString())
 	if err != nil {
 		if strings.Contains(err.Error(), "unexpected status code: 404") {
 			resp.State.RemoveResource(ctx)
-			resp.Diagnostics.Append(resp.Identity.Set(ctx, Z3BucketIdentityModel{Name: state.Name})...)
+			resp.Diagnostics.Append(resp.Identity.Set(ctx, stateIdentity)...)
 			return
 		}
 		resp.Diagnostics.AddError("Error Reading Z3 Bucket", err.Error())

--- a/internal/provider/z3_object_resource.go
+++ b/internal/provider/z3_object_resource.go
@@ -200,6 +200,7 @@ func (r *Z3ObjectResource) Update(ctx context.Context, req resource.UpdateReques
 			"Error Updating Z3 Object",
 			"Could not update Z3 object: "+err.Error(),
 		)
+		resp.Diagnostics.Append(resp.Identity.Set(ctx, Z3ObjectIdentityModel{Bucket: plan.Bucket, Key: plan.Key})...)
 		return
 	}
 
@@ -209,6 +210,7 @@ func (r *Z3ObjectResource) Update(ctx context.Context, req resource.UpdateReques
 			"Error Retrieving Z3 Object",
 			"Could not retrieve Z3 object: "+err.Error(),
 		)
+		resp.Diagnostics.Append(resp.Identity.Set(ctx, Z3ObjectIdentityModel{Bucket: plan.Bucket, Key: plan.Key})...)
 		return
 	}
 

--- a/internal/provider/z3_object_resource.go
+++ b/internal/provider/z3_object_resource.go
@@ -213,7 +213,13 @@ func (r *Z3ObjectResource) Update(ctx context.Context, req resource.UpdateReques
 	}
 
 	result := convertClientObjectToZ3Object(returnedObject, plan.Bucket.ValueString(), plan.Source.ValueString(), plan.SourceChecksum.ValueString())
+	retIdentity := Z3ObjectIdentityModel{
+		Bucket: plan.Bucket,
+		Key:    plan.Key,
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, result)...)
+	resp.Diagnostics.Append(resp.Identity.Set(ctx, retIdentity)...)
 }
 
 func (r *Z3ObjectResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/provider/z3_object_resource.go
+++ b/internal/provider/z3_object_resource.go
@@ -168,6 +168,7 @@ func (r *Z3ObjectResource) Read(ctx context.Context, req resource.ReadRequest, r
 	if err != nil {
 		if strings.Contains(err.Error(), "unexpected status code: 404") {
 			resp.State.RemoveResource(ctx)
+			resp.Diagnostics.Append(resp.Identity.Set(ctx, Z3ObjectIdentityModel{Bucket: state.Bucket, Key: state.Key})...)
 			return
 		}
 		resp.Diagnostics.AddError(
@@ -194,13 +195,15 @@ func (r *Z3ObjectResource) Update(ctx context.Context, req resource.UpdateReques
 		return
 	}
 
+	stateIdentity := Z3ObjectIdentityModel{Bucket: plan.Bucket, Key: plan.Key}
+
 	err := r.client.Z3.UploadObject(ctx, plan.Bucket.ValueString(), plan.Key.ValueString(), plan.Source.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error Updating Z3 Object",
 			"Could not update Z3 object: "+err.Error(),
 		)
-		resp.Diagnostics.Append(resp.Identity.Set(ctx, Z3ObjectIdentityModel{Bucket: plan.Bucket, Key: plan.Key})...)
+		resp.Diagnostics.Append(resp.Identity.Set(ctx, stateIdentity)...)
 		return
 	}
 
@@ -210,7 +213,7 @@ func (r *Z3ObjectResource) Update(ctx context.Context, req resource.UpdateReques
 			"Error Retrieving Z3 Object",
 			"Could not retrieve Z3 object: "+err.Error(),
 		)
-		resp.Diagnostics.Append(resp.Identity.Set(ctx, Z3ObjectIdentityModel{Bucket: plan.Bucket, Key: plan.Key})...)
+		resp.Diagnostics.Append(resp.Identity.Set(ctx, stateIdentity)...)
 		return
 	}
 

--- a/internal/provider/z3_object_resource.go
+++ b/internal/provider/z3_object_resource.go
@@ -164,11 +164,13 @@ func (r *Z3ObjectResource) Read(ctx context.Context, req resource.ReadRequest, r
 		return
 	}
 
+	stateIdentity := Z3ObjectIdentityModel{Bucket: state.Bucket, Key: state.Key}
+
 	object, err := r.client.Z3.ListObject(ctx, state.Bucket.ValueString(), state.Key.ValueString())
 	if err != nil {
 		if strings.Contains(err.Error(), "unexpected status code: 404") {
 			resp.State.RemoveResource(ctx)
-			resp.Diagnostics.Append(resp.Identity.Set(ctx, Z3ObjectIdentityModel{Bucket: state.Bucket, Key: state.Key})...)
+			resp.Diagnostics.Append(resp.Identity.Set(ctx, stateIdentity)...)
 			return
 		}
 		resp.Diagnostics.AddError(

--- a/internal/provider/zambda_resource.go
+++ b/internal/provider/zambda_resource.go
@@ -366,8 +366,12 @@ func (r *ZambdaResource) Update(ctx context.Context, req resource.UpdateRequest,
 	}
 
 	retZambda := convertClientZambdaToZambda(ctx, retrievedZambda, plan.SourceChecksum.ValueString())
+	retIdentity := IDIdentityModel{
+		ID: retZambda.ID,
+	}
 
-	resp.State.Set(ctx, retZambda)
+	resp.Diagnostics.Append(resp.State.Set(ctx, retZambda)...)
+	resp.Diagnostics.Append(resp.Identity.Set(ctx, retIdentity)...)
 }
 
 func (r *ZambdaResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/provider/zambda_resource.go
+++ b/internal/provider/zambda_resource.go
@@ -332,9 +332,12 @@ func (r *ZambdaResource) Update(ctx context.Context, req resource.UpdateRequest,
 
 	zambda := convertZambdaToClientZambda(ctx, plan)
 
+	stateIdentity := IDIdentityModel{ID: state.ID}
+
 	updatedZambda, err := r.client.Zambda.UpdateZambda(ctx, state.ID.ValueString(), &zambda)
 	if err != nil {
 		resp.Diagnostics.AddError("Error Updating Zambda", err.Error())
+		resp.Diagnostics.Append(resp.Identity.Set(ctx, stateIdentity)...)
 		return
 	}
 
@@ -350,6 +353,7 @@ func (r *ZambdaResource) Update(ctx context.Context, req resource.UpdateRequest,
 				if err != nil {
 					resp.Diagnostics.AddError("Error Rolling Back Zambda Update", err.Error())
 				}
+				resp.Diagnostics.Append(resp.Identity.Set(ctx, stateIdentity)...)
 				return
 			}
 		}
@@ -358,10 +362,12 @@ func (r *ZambdaResource) Update(ctx context.Context, req resource.UpdateRequest,
 	retrievedZambda, err := r.getZambdaAfterMutation(ctx, &resp.Diagnostics, *updatedZambda.ID, plan.SourceChecksum.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Error Retrieving Created Zambda", err.Error())
+		resp.Diagnostics.Append(resp.Identity.Set(ctx, stateIdentity)...)
 		return
 	}
 	if retrievedZambda == nil {
 		// Error already added to diagnostics in getZambdaAfterMutation
+		resp.Diagnostics.Append(resp.Identity.Set(ctx, stateIdentity)...)
 		return
 	}
 

--- a/internal/provider/zambda_resource.go
+++ b/internal/provider/zambda_resource.go
@@ -303,6 +303,7 @@ func (r *ZambdaResource) Read(ctx context.Context, req resource.ReadRequest, res
 	if err != nil {
 		if strings.Contains(err.Error(), "unexpected status code: 404") {
 			resp.State.RemoveResource(ctx)
+			resp.Diagnostics.Append(resp.Identity.Set(ctx, IDIdentityModel{ID: state.ID})...)
 			return
 		}
 		resp.Diagnostics.AddError("Error Reading Zambda", err.Error())

--- a/internal/provider/zambda_resource.go
+++ b/internal/provider/zambda_resource.go
@@ -299,11 +299,13 @@ func (r *ZambdaResource) Read(ctx context.Context, req resource.ReadRequest, res
 		id = state.ID.ValueString()
 	}
 
+	stateIdentity := IDIdentityModel{ID: state.ID}
+
 	zambda, err := r.client.Zambda.GetZambda(ctx, id)
 	if err != nil {
 		if strings.Contains(err.Error(), "unexpected status code: 404") {
 			resp.State.RemoveResource(ctx)
-			resp.Diagnostics.Append(resp.Identity.Set(ctx, IDIdentityModel{ID: state.ID})...)
+			resp.Diagnostics.Append(resp.Identity.Set(ctx, stateIdentity)...)
 			return
 		}
 		resp.Diagnostics.AddError("Error Reading Zambda", err.Error())


### PR DESCRIPTION
⏺ Summary                                                                                                                                                                                                           
                                                                                                                                                                                                                    
  Root cause: Every Update function across all 9 updatable resources sets resp.State but never sets resp.Identity. Since all resources implement ResourceWithIdentity, Terraform Framework expects identity data    
  after any successful CRUD operation. When Update completes without error but with no identity, Terraform raises "missing resource identity after read."
                                                                                                                                                                                                                    
  Fix: Added resp.Identity.Set() calls to all 9 Update functions, matching the identity construction pattern already used in each resource's Create and Read functions.                                             
                                                                                                                                                                                                                    
  Affected resources:                                                                                                                                                                                               
  - zambda_resource.go (IDIdentityModel)                                                                                                                                                                            
  - application_resource.go (IDIdentityModel)                                                                                                                                                                       
  - role_resource.go (IDIdentityModel)       
  - m2m_resource.go (IDIdentityModel)                                                                                                                                                                               
  - project_config_resource.go (IDIdentityModel)            
  - fhir_resource.go (FhirResourceIdentityModel)                                                                                                                                                                    
  - secret_resource.go (SecretIdentityModel)    
  - z3_bucket_resource.go (Z3BucketIdentityModel)                                                                                                                                                                   
  - z3_object_resource.go (Z3ObjectIdentityModel)           
                                                                                                                                                                                                                    
  The 2 resources with unsupported Updates (fax_number, lab_route) were not affected since their Update functions return an error immediately.