### PR TITLE
Skip update zambda function if no function changes

### DIFF
--- a/internal/provider/zambda_resource.go
+++ b/internal/provider/zambda_resource.go
@@ -334,27 +334,32 @@ func (r *ZambdaResource) Update(ctx context.Context, req resource.UpdateRequest,
 	}
 
 	zambda := convertZambdaToClientZambda(ctx, plan)
+	functionFieldsChanged := zambdaFunctionFieldsChanged(plan, state)
 
 	stateIdentity := IDIdentityModel{ID: state.ID}
 
-	updatedZambda, err := r.client.Zambda.UpdateZambda(ctx, state.ID.ValueString(), &zambda)
-	if err != nil {
-		resp.Diagnostics.AddError("Error Updating Zambda", err.Error())
-		resp.Diagnostics.Append(resp.Identity.Set(ctx, stateIdentity)...)
-		return
+	if functionFieldsChanged {
+		_, err := r.client.Zambda.UpdateZambda(ctx, state.ID.ValueString(), &zambda)
+		if err != nil {
+			resp.Diagnostics.AddError("Error Updating Zambda", err.Error())
+			resp.Diagnostics.Append(resp.Identity.Set(ctx, stateIdentity)...)
+			return
+		}
 	}
 
 	if config.Source.ValueString() != "" {
 		// Different checksum, upload new source and use calculated checksum
 		if plan.SourceChecksum.ValueString() != state.SourceChecksum.ValueString() {
-			err = r.client.Zambda.UploadZambdaSource(ctx, *updatedZambda.ID, config.Source.ValueString())
+			err := r.client.Zambda.UploadZambdaSource(ctx, state.ID.ValueString(), config.Source.ValueString())
 			if err != nil {
 				resp.Diagnostics.AddError("Error Uploading Zambda Source", err.Error())
-				// Roll back update
-				previousStateZambda := convertZambdaToClientZambda(ctx, state)
-				_, err = r.client.Zambda.UpdateZambda(ctx, state.ID.ValueString(), &previousStateZambda)
-				if err != nil {
-					resp.Diagnostics.AddError("Error Rolling Back Zambda Update", err.Error())
+				if functionFieldsChanged {
+					// Roll back update when function fields were changed before source upload.
+					previousStateZambda := convertZambdaToClientZambda(ctx, state)
+					_, err = r.client.Zambda.UpdateZambda(ctx, state.ID.ValueString(), &previousStateZambda)
+					if err != nil {
+						resp.Diagnostics.AddError("Error Rolling Back Zambda Update", err.Error())
+					}
 				}
 				resp.Diagnostics.Append(resp.Identity.Set(ctx, stateIdentity)...)
 				return
@@ -362,7 +367,7 @@ func (r *ZambdaResource) Update(ctx context.Context, req resource.UpdateRequest,
 		}
 	}
 
-	retrievedZambda, err := r.getZambdaAfterMutation(ctx, &resp.Diagnostics, *updatedZambda.ID, plan.SourceChecksum.ValueString())
+	retrievedZambda, err := r.getZambdaAfterMutation(ctx, &resp.Diagnostics, state.ID.ValueString(), plan.SourceChecksum.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Error Retrieving Created Zambda", err.Error())
 		resp.Diagnostics.Append(resp.Identity.Set(ctx, stateIdentity)...)
@@ -381,6 +386,11 @@ func (r *ZambdaResource) Update(ctx context.Context, req resource.UpdateRequest,
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, retZambda)...)
 	resp.Diagnostics.Append(resp.Identity.Set(ctx, retIdentity)...)
+}
+
+func zambdaFunctionFieldsChanged(plan, state Zambda) bool {
+	// TODO: implement field-by-field diff for function metadata updates.
+	return true
 }
 
 func (r *ZambdaResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/provider/zambda_resource.go
+++ b/internal/provider/zambda_resource.go
@@ -333,12 +333,12 @@ func (r *ZambdaResource) Update(ctx context.Context, req resource.UpdateRequest,
 		return
 	}
 
-	zambda := convertZambdaToClientZambda(ctx, plan)
 	functionFieldsChanged := zambdaFunctionFieldsChanged(plan, state)
 
 	stateIdentity := IDIdentityModel{ID: state.ID}
 
 	if functionFieldsChanged {
+		zambda := convertZambdaToClientZambda(ctx, plan)
 		_, err := r.client.Zambda.UpdateZambda(ctx, state.ID.ValueString(), &zambda)
 		if err != nil {
 			resp.Diagnostics.AddError("Error Updating Zambda", err.Error())
@@ -390,7 +390,7 @@ func (r *ZambdaResource) Update(ctx context.Context, req resource.UpdateRequest,
 
 func zambdaFunctionFieldsChanged(plan, state Zambda) bool {
 	return !plan.Name.Equal(state.Name) ||
-		plan.Runtime.ValueString() != state.Runtime.ValueString() ||
+		!plan.Runtime.Equal(state.Runtime) ||
 		!plan.MemorySize.Equal(state.MemorySize) ||
 		!plan.Timeout.Equal(state.Timeout) ||
 		!plan.TriggerMethod.Equal(state.TriggerMethod) ||

--- a/internal/provider/zambda_resource.go
+++ b/internal/provider/zambda_resource.go
@@ -389,8 +389,12 @@ func (r *ZambdaResource) Update(ctx context.Context, req resource.UpdateRequest,
 }
 
 func zambdaFunctionFieldsChanged(plan, state Zambda) bool {
-	// TODO: implement field-by-field diff for function metadata updates.
-	return true
+	return !plan.Name.Equal(state.Name) ||
+		plan.Runtime.ValueString() != state.Runtime.ValueString() ||
+		!plan.MemorySize.Equal(state.MemorySize) ||
+		!plan.Timeout.Equal(state.Timeout) ||
+		!plan.TriggerMethod.Equal(state.TriggerMethod) ||
+		!plan.Schedule.Equal(state.Schedule)
 }
 
 func (r *ZambdaResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/provider/zambda_resource_test.go
+++ b/internal/provider/zambda_resource_test.go
@@ -1,0 +1,56 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+func TestZambdaFunctionFieldsChanged_CodeOnlyChange_ReturnsFalse(t *testing.T) {
+	state := Zambda{
+		Name:           types.StringValue("orders-worker"),
+		Runtime:        RuntimeValue{StringValue: basetypes.NewStringValue("nodejs20.x")},
+		MemorySize:     types.Int32Value(1024),
+		Timeout:        types.Int32Value(30),
+		TriggerMethod:  types.StringValue("http_auth"),
+		Schedule:       types.ObjectNull(scheduleAttrTypes()),
+		SourceChecksum: types.StringValue("checksum-old"),
+	}
+	plan := state
+	plan.SourceChecksum = types.StringValue("checksum-new")
+
+	if zambdaFunctionFieldsChanged(plan, state) {
+		t.Fatalf("expected no function field changes for code-only update, but got true")
+	}
+}
+
+func TestZambdaFunctionFieldsChanged_FunctionChange_ReturnsTrue(t *testing.T) {
+	state := Zambda{
+		Name:          types.StringValue("orders-worker"),
+		Runtime:       RuntimeValue{StringValue: basetypes.NewStringValue("nodejs20.x")},
+		MemorySize:    types.Int32Value(1024),
+		Timeout:       types.Int32Value(30),
+		TriggerMethod: types.StringValue("http_auth"),
+		Schedule:      types.ObjectNull(scheduleAttrTypes()),
+	}
+	plan := state
+	plan.Timeout = types.Int32Value(60)
+
+	if !zambdaFunctionFieldsChanged(plan, state) {
+		t.Fatalf("expected function field changes when timeout changed, but got false")
+	}
+}
+
+func scheduleAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"expression": types.StringType,
+		"start":      types.StringType,
+		"end":        types.StringType,
+		"retry_policy": types.ObjectType{AttrTypes: map[string]attr.Type{
+			"maximum_event_age": types.Int64Type,
+			"maximum_retry":     types.Int64Type,
+		}},
+	}
+}


### PR DESCRIPTION
Zambda Function resource changed to do a strong diff of Function state. If there are no function changes and only code changes skip calling to update function.